### PR TITLE
Add Gangnam Hackbar real estate shortlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Hackbar Real Estate Research
+
+This repository contains a Gangnam real estate shortlist for [Issue #1](https://github.com/ubiquity/hackbar/issues/1).
+
+Primary deliverable:
+
+- [Gangnam Hackbar Real Estate Shortlist](./gangnam-hackbar-real-estate-shortlist.md)

--- a/gangnam-hackbar-real-estate-shortlist.md
+++ b/gangnam-hackbar-real-estate-shortlist.md
@@ -1,0 +1,132 @@
+# Gangnam Hackbar Real Estate Shortlist
+
+Prepared for [ubiquity/hackbar#1](https://github.com/ubiquity/hackbar/issues/1) on 2026-05-13.
+
+## Summary
+
+The best current fit is **Prime Building, Yeoksam-dong** because it matches the requested Gangnam location, is already close to the 140 m2 target in spirit but much larger at 462.81 m2 exclusive area, has multiple rooms plus an open hall, sits within walking distance of Yeoksam Station, and keeps the listed deposit below the issue's 250,000 USD ceiling at typical recent USD/KRW ranges.
+
+The second-best practical fit is **Hwanghwa Building, Gangnam-daero** because it is on Gangnam-daero, has mixed office/retail/clinic suitability, immediate move-in, and a strong room layout for office plus lounge/bar programming.
+
+## Selection Criteria
+
+| Criterion | Weight | Why it matters |
+| --- | ---: | --- |
+| Gangnam core accessibility | 25 | The venue needs to be easy for builders, partners, and visitors to find. |
+| Space fit and layout | 25 | Hackbar needs open work space plus private rooms and event/lounge flexibility. |
+| Deposit within budget | 20 | The issue caps security deposit at 250,000 USD. |
+| Monthly fixed cost | 15 | Rent plus management fee should be explainable against expected usage. |
+| Conversion friction | 15 | Existing office/retail fit, restrooms, elevators, parking, and move-in timing lower execution risk. |
+
+## Ranked Candidates
+
+| Rank | Candidate | Area | Deposit | Monthly Rent | Mgmt Fee | Score | Recommendation |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 1 | Prime Building, Yeoksam-dong | 462.81 m2 exclusive / 539.12 m2 leased | KRW 240M | KRW 20M | KRW 5M | 87 | Primary target |
+| 2 | Hwanghwa Building, Gangnam-daero | 396.69 m2 exclusive / 757.02 m2 leased | KRW 300M | KRW 16M | KRW 4.58M | 84 | Strong alternative |
+| 3 | J Tower, Sinsa-dong | 330.6 m2 exclusive / 624.8 m2 supplied | KRW 245.7M | KRW 24.57M | KRW 9.45M | 76 | Premium Shinbundang/Line 3 option |
+| 4 | Geumgang Tower, Daechi-dong | 301.69 m2 exclusive / 578.35 m2 supplied | KRW 209.44M | KRW 20.99M | KRW 6.42M | 73 | Good transport, smaller footprint |
+| 5 | SKW / former Classy Tower, Yeoksam-dong | 135.97 m2 exclusive / 205.69 m2 leased | KRW 99.81M est. | KRW 9.98M est. | KRW 2.5M est. | 61 | Pilot office only; too small for full Hackbar |
+| 6 | The Executive Centre, Glass Tower | serviced/flexible office | quote needed | from membership pricing | included/varies | 58 | Temporary landing option |
+
+## Candidate Notes
+
+### 1. Prime Building, Yeoksam-dong
+
+Source: <https://withusrealty.co.kr/item/view/13975>
+
+- Listed as a 4th-floor whole-floor office in Gangnam-gu Yeoksam-dong.
+- Exclusive area: 462.81 m2 / 140 pyeong; leased area: 539.12 m2 / 163.08 pyeong.
+- Deposit KRW 240M, rent KRW 20M, management fee KRW 5M.
+- Layout includes office hall plus multiple rooms; listing says restoration is possible.
+- Subway access: Yeoksam, Gangnam, and Seolleung are referenced; listing notes Yeoksam Station around five minutes on foot.
+- Parking: 4 included spaces, with additional parking negotiable.
+- Why it fits: It is the closest direct match to a combined office and venue layout without needing a large retail premium.
+- Key diligence: confirm whether food/beverage operation or private bar use is permitted under lease and building rules.
+
+### 2. Hwanghwa Building, Gangnam-daero
+
+Source: <https://withusrealty.co.kr/item/view/13131>
+
+- Listed as Gangnam-daero office space in Yeoksam-dong.
+- Exclusive area: 396.69 m2 / 120 pyeong; leased area: 757.02 m2 / 229 pyeong.
+- Deposit KRW 300M, rent KRW 16M, management fee KRW 4.58M.
+- Theme includes office, retail, and clinic; immediate move-in.
+- Layout: hall plus six rooms, storage, pantry, external separated restrooms.
+- Parking: listing indicates five spaces in the detail text.
+- Why it fits: Mixed-use positioning and Gangnam-daero visibility make it a practical Hackbar candidate if the owner permits events.
+- Key diligence: verify if the KRW 300M deposit still fits the final USD conversion budget at signing date.
+
+### 3. J Tower, Sinsa-dong
+
+Source: <https://officeleasing.co.kr/%EA%B0%95%EB%82%A8%EC%82%AC%EB%AC%B4%EC%8B%A4%EC%9E%84%EB%8C%80/%EC%8B%A0%EC%82%AC%EB%8F%99/%EC%A0%9C%EC%9D%B4%ED%83%80%EC%9B%8C/>
+
+- Address: 139 Dosan-daero, Gangnam-gu.
+- Exclusive area: 330.6 m2 / 100 pyeong; supplied area: 624.8 m2 / 189 pyeong.
+- Deposit KRW 245.7M, rent KRW 24.57M, management fee KRW 9.45M.
+- Near Sinsa Station on Line 3 and Shinbundang Line.
+- Strong visitor impression: glass office building, lobby, four elevators, four basic parking spaces.
+- Why it fits: High-quality access and brand value for partner meetings.
+- Key diligence: the monthly fixed cost is materially higher than Yeoksam options.
+
+### 4. Geumgang Tower, Daechi-dong
+
+Source: <https://officeleasing.co.kr/%EA%B0%95%EB%82%A8%EC%82%AC%EB%AC%B4%EC%8B%A4%EC%9E%84%EB%8C%80/%EB%8C%80%EC%B9%98%EB%8F%99/%EA%B8%88%EA%B0%95%ED%83%80%EC%9B%8C/>
+
+- Address: 410 Teheran-ro, Gangnam-gu.
+- Exclusive area: 301.69 m2 / 91.26 pyeong; supplied area: 578.35 m2 / 174.95 pyeong.
+- Deposit KRW 209.44M, rent KRW 20.99M, management fee KRW 6.42M.
+- Near Seolleung Station on Line 2 and Suin-Bundang Line.
+- Why it fits: Good transport, lower deposit, and efficient divisible office layout.
+- Key diligence: only two basic parking spaces and smaller exclusive footprint.
+
+### 5. SKW / Former Classy Tower, Yeoksam-dong
+
+Source: <https://www.officefind.co.kr/5886>
+
+- Address: 502 Gangnam-daero, Gangnam-gu.
+- Standard floor: 205.69 m2 leased / 135.97 m2 exclusive.
+- Estimated deposit KRW 99.81M, rent KRW 9.98M, management fee KRW 2.5M from the listing calculator.
+- Near Gangnam and Yeoksam access, strong road visibility.
+- Why it fits: Useful as a low-commitment pilot office.
+- Why it is not top-ranked: too small for the full office plus bar concept.
+
+### 6. The Executive Centre, Glass Tower
+
+Source: <https://www.executivecentre.co.kr/office-space/seoul-glass-tower/>
+
+- Address: 20F, Glass Tower, 534 Teheran-ro, Gangnam-gu.
+- Samsung Station access and COEX proximity.
+- Flexible office, day office, hot desk, meeting room, and virtual office products.
+- Why it fits: Best for temporary presence while negotiating a full lease.
+- Why it is not top-ranked: serviced office structure is not a standalone Hackbar/bar conversion.
+
+## Rejected or Watchlist Options
+
+| Candidate | Reason |
+| --- | --- |
+| Centerfield, Yeoksam | Excellent building, but the listed deposit and monthly rent are far above the current budget band. |
+| Parnas Tower, Samseong | Landmark access, but the listed area and deposit are too large for the issue constraints. |
+| Small B1 retail spaces near Sinnonhyeon/Gangnam | Better for a bar, but generally too small for office plus community/event use. |
+
+## Recommended Next Steps
+
+1. Contact Prime Building and Hwanghwa Building brokers first.
+2. Ask for current vacancy, landlord approval for evening events, beverage service, signage, sound restrictions, restoration obligations, and rent-free/fit-out period.
+3. Request floor plans and recent interior photos before scheduling in-person visits.
+4. Run legal/zoning review before any deposit transfer.
+5. If neither top candidate permits lounge/bar/event use, use J Tower as the premium office alternative and run a separate search for an event/lounge partner nearby.
+
+## Broker Outreach Script
+
+English:
+
+> Hello, we are looking for a Gangnam venue that can operate as a hybrid office, private community lounge, and small event space. We saw your listing and would like to confirm current availability, permitted use, landlord approval for evening events, sound restrictions, food/beverage rules, signage options, rent-free period, fit-out period, and whether the deposit/rent are negotiable for a 2-3 year lease.
+
+Korean:
+
+> 안녕하세요. 강남권에서 사무실, 프라이빗 커뮤니티 라운지, 소규모 이벤트 공간을 겸할 수 있는 공간을 찾고 있습니다. 해당 매물의 현재 공실 여부, 야간 행사 가능 여부, 소음 제한, 식음료 제공 가능 여부, 간판 가능 여부, 렌트프리/핏아웃 기간, 2-3년 임대 기준 보증금과 월세 협의 가능 여부를 확인하고 싶습니다.
+
+## Final Recommendation
+
+Proceed with **Prime Building, Yeoksam-dong** as the first call. It is the best balance of size, budget, station access, layout, and execution risk. Keep **Hwanghwa Building** as the second call because its mixed-use positioning may make office plus lounge operation easier if the landlord is flexible.


### PR DESCRIPTION
## Summary
- Adds a Gangnam real estate shortlist for #1 with six ranked options.
- Scores candidates by access, layout fit, deposit budget, monthly cost, and conversion friction.
- Recommends Prime Building in Yeoksam-dong as the first call and Hwanghwa Building on Gangnam-daero as the backup.

## Deliverable
- Report: gangnam-hackbar-real-estate-shortlist.md
- Includes source links, decision matrix, rejected/watchlist options, diligence questions, and English/Korean broker outreach scripts.

## Notes
- Desk research from public listings; availability, zoning, food/beverage permission, event permission, and lease terms need broker/landlord confirmation before deposit transfer.

Closes #1