### PR TITLE
Add Andy Tea Scent business plan draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Hackbar Research
+
+This repository contains research deliverables for Hackbar issues.
+
+## Deliverables
+
+- [Andy's Tea Scent Business Plan Draft](./andy-tea-scent-business-plan.md)

--- a/andy-tea-scent-business-plan.md
+++ b/andy-tea-scent-business-plan.md
@@ -1,0 +1,258 @@
+# Andy's Tea Scent Business Plan Draft
+
+Prepared for [ubiquity/hackbar#2](https://github.com/ubiquity/hackbar/issues/2) on 2026-05-13.
+
+## Access Note
+
+The linked Google Doc in the issue was not publicly accessible at the time of drafting, returning an authorization error. This draft is therefore a collaboration-ready first version based on the GitHub issue, public interviews and market-facing references about Andy Yoon and Bar Tea Scent, and public tea aroma / tea mixology context. It should be reconciled with Andy's private Tea Scent plan once access is granted.
+
+## Executive Summary
+
+Bar Tea Scent can be positioned as the flagship brand for a broader "Korean tea mixology" platform: a premium hospitality venue, a consulting and training studio, and a future product/IP business around tea-infused spirits, non-alcoholic tea pairings, and sensory education.
+
+The core opportunity is that Andy already has proof of demand. Public coverage describes Bar Tea Scent as a successful Gangnam venue built around tea omakase, tea-infused spirits, rare single-origin teas, tea food, and signature cocktails served with or without alcohol. Andy has also expanded into multiple conceptual venues and consulting work, which suggests the brand is not a single-location novelty but a repeatable hospitality and beverage-development capability.
+
+Recommended near-term priority:
+
+1. Keep Bar Tea Scent as the flagship experience.
+2. Turn consulting into a packaged B2B product.
+3. Create high-margin workshops and private events.
+4. Build a small bottled/pre-batched tea cocktail and non-alcoholic pairing test line.
+5. Prepare a long-term tea spirits/distillery roadmap without over-investing before demand is proven.
+
+## Brand Thesis
+
+Tea Scent should own the intersection of:
+
+- Korean tea culture.
+- Modern cocktail craft.
+- Perfumery-inspired aroma design.
+- Low-ABV and non-alcoholic pairing.
+- Fine-dining style service in an intimate bar setting.
+
+The brand should avoid being framed only as a "tea cocktail bar." The stronger frame is:
+
+> A sensory bar and beverage lab translating Korean tea into cocktails, non-alcoholic pairings, consulting programs, and future tea spirits.
+
+## Public Signals
+
+Public material supports the following assumptions:
+
+- Bar Tea Scent is located in Seoul's Gangnam district and focuses on tea mixology.
+- Andy Yoon is described as a bartender, consultant at ABC Laboratory, and brand ambassador for Kennedy House Spirits.
+- Bar Tea Scent offers a five-course tea omakase, tea-infused spirits by glass or bottle, rare single-origin teas, tea-infused bar food, and signature tea cocktails with or without alcohol.
+- Andy has expanded into other concepts including Bar Geranium, Calvados Garden, Gallery Bar Ebb & Flow, and Truffle di Alba.
+- Andy identifies localization, modern technology, and sustainability as major tea mixology trends.
+- Andy's longer-term ambition includes distilling and distributing spirits made with local Korean teas.
+
+Sources:
+
+- <https://masterstalk.online/2024/07/22/tea-mixology-redefined-inside-andy-yoons-bar-tea-scent/>
+- <https://www.prnewswire.com/news-releases/the-scents-of-tea-first-of-its-kind-tea-aroma-kit-launches-300921825.html>
+- <https://teajourney.pub/curios-tea-scent/>
+- <https://www.mdpi.com/2304-8158/14/15/2574>
+
+## Customer Segments
+
+| Segment | Need | Product fit | Revenue potential |
+| --- | --- | --- | --- |
+| Cocktail enthusiasts | New Seoul bar experience | Signature tea cocktails, omakase | High |
+| Tea enthusiasts | Deeper tasting and education | Rare tea flights, workshops | Medium |
+| Fine-dining customers | Pairing experience | Low-ABV and non-alcoholic pairing menu | High |
+| Visiting bartenders | Skill transfer | Masterclasses and guest shifts | Medium |
+| Hotels and restaurants | Menu differentiation | Consulting packages | High |
+| Brands/importers | Launch and education | Sponsored events and menu collaborations | High |
+| International guests | Korean cultural experience | English-language tasting, concierge partnerships | Medium |
+
+## Product Architecture
+
+### 1. Flagship Bar
+
+Core products:
+
+- Five-course tea omakase.
+- Seasonal tea cocktail menu.
+- Non-alcoholic tea pairing menu.
+- Rare single-origin tea service.
+- Tea-infused bar food.
+- Tea spirits by glass or bottle.
+
+Operating goal:
+
+- Protect the flagship as the proof point and content engine.
+- Keep menus seasonal to create repeat visits.
+- Track which drinks convert best into workshop, product, or consulting demand.
+
+### 2. Tea Scent Lab
+
+Core products:
+
+- B2B beverage menu development.
+- Tea cocktail staff training.
+- Non-alcoholic pairing development for restaurants.
+- Bar opening or refresh consulting.
+- Tea aroma and ingredient sourcing workshops.
+
+Suggested package ladder:
+
+| Package | Scope | Indicative price band |
+| --- | --- | ---: |
+| Menu Audit | 1-day review, 5-7 recommendations | KRW 1.5M-3M |
+| Signature Menu Sprint | 4-6 drinks, recipes, costing, prep guide | KRW 6M-12M |
+| Opening Program | Concept, menu, training, launch support | KRW 20M-50M |
+| Retainer | Seasonal menu and staff refresh | KRW 3M-8M/month |
+
+### 3. Education and Events
+
+Core products:
+
+- Tea mixology masterclass.
+- Tea and food pairing dinner.
+- Non-alcoholic pairing workshop.
+- Corporate sensory workshop.
+- Private tea omakase buyout.
+
+Why it matters:
+
+- Higher margin than standard bar service.
+- Creates repeatable content.
+- Builds the next funnel for consulting and product launches.
+
+### 4. Product and IP
+
+Near-term products:
+
+- Bottled tea cocktail bases for internal use and events.
+- Tea tinctures and syrups for partner bars.
+- Limited tea aroma kit for workshops.
+- Recipe zine or digital course.
+
+Long-term products:
+
+- Korean tea spirits.
+- Non-alcoholic distilled tea spirit.
+- Exportable bar-in-a-box program for international partners.
+
+## Positioning
+
+### Short Positioning
+
+Tea Scent is Korea's sensory tea mixology platform, translating local teas into cocktails, pairings, education, consulting, and future tea spirits.
+
+### One-Liner
+
+Bar Tea Scent turns Korean tea into a modern drinking experience.
+
+### Customer Promise
+
+Guests leave with a new memory of tea: not just something brewed, but something smelled, paired, distilled, mixed, and staged.
+
+## Competitive Landscape
+
+The relevant competitive set is not only cocktail bars. It includes:
+
+- Premium cocktail bars.
+- Tea houses.
+- Fine-dining beverage pairings.
+- Non-alcoholic pairing programs.
+- Perfumery and sensory workshops.
+- Beverage consulting agencies.
+- Distilled non-alcoholic spirits.
+
+Tea Scent's advantage is the combination of hospitality credibility, tea knowledge, sensory staging, consulting experience, and Korean ingredient localization.
+
+## Revenue Model
+
+### Revenue Streams
+
+| Stream | Timing | Margin | Strategic value |
+| --- | --- | --- | --- |
+| Flagship bar sales | Now | Medium | Brand proof and cash flow |
+| Omakase / tasting menu | Now | High | Premium positioning |
+| Private events | Now | High | B2B and concierge relationships |
+| Workshops | 0-3 months | High | Scalable education |
+| Consulting | 0-6 months | High | Uses Andy's expertise beyond seats |
+| Sponsored menu collaborations | 3-9 months | Medium-high | Brand partnerships |
+| Bottled bases / tinctures | 6-12 months | Medium | Product validation |
+| Tea spirits | 18+ months | Unknown | Long-term upside |
+
+### Operating Priorities
+
+1. Measure contribution margin by product line.
+2. Separate venue revenue from consulting revenue.
+3. Build a CRM of guests, partners, and workshop attendees.
+4. Convert international press into inbound consulting and guest-shift opportunities.
+5. Keep capital-heavy product development gated by small pilots.
+
+## 12-Month Roadmap
+
+### Months 1-2: Clarify the Business
+
+- Reconcile this draft with Andy's private plan.
+- Build a product P&L for current bar, events, and consulting.
+- Define the Tea Scent brand hierarchy.
+- Standardize the consulting menu and workshop formats.
+- Create a simple investor/partner deck.
+
+### Months 3-4: Package and Sell
+
+- Launch 2 monthly public workshops.
+- Offer 3 private corporate/event packages.
+- Create a case-study template for consulting clients.
+- Build a mailing list and booking funnel.
+- Begin outreach to hotels, fine-dining restaurants, liquor importers, and Korean tea producers.
+
+### Months 5-6: Validate Product Extension
+
+- Test 3 bottled bases or tinctures with partner bars.
+- Create a seasonal non-alcoholic pairing menu.
+- Run one sponsored Korean tea collaboration.
+- Track repeat purchase and event inquiry conversion.
+
+### Months 7-9: Scale Partnerships
+
+- Package a "Tea Scent Lab" consulting retainer.
+- Run international guest shifts in 2-3 cities.
+- Secure one hotel or restaurant consulting client.
+- Publish a bilingual brand story and media kit.
+
+### Months 10-12: Decide Expansion Path
+
+- Decide whether to expand through a second owned venue, partner venue, packaged consulting, or product line.
+- Prepare a tea spirits feasibility study.
+- Evaluate licensing, production, compliance, and distribution partners.
+
+## Key Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Concept is too niche | Limits repeat visits | Keep cocktails approachable and offer non-tea entry points |
+| Andy is the bottleneck | Hard to scale | Build training manuals, recipes, and second-line educators |
+| Product development gets capital-heavy | Cash drain | Gate products through pop-ups and partner pilots |
+| Tea education feels intimidating | Lower conversion | Use sensory storytelling, simple tasting cards, and guided pairings |
+| Alcohol market regulation | Delays spirits roadmap | Keep spirits as phase 2; start with consulting and events |
+| Venue revenue volatility | Cash-flow pressure | Grow consulting, workshops, and private events |
+
+## Collaboration Questions for Andy
+
+1. What is the main goal: one stronger venue, multi-venue expansion, consulting scale, packaged products, or future distillery?
+2. What are current monthly revenues by bar sales, omakase, events, and consulting?
+3. Which drinks or services have the highest margin?
+4. What does Andy personally want to keep doing versus delegate?
+5. Which parts of the private Tea Scent plan are already validated?
+6. Is the distillery dream a brand story, a 3-year project, or a capital raise target?
+7. Which partners already exist: tea producers, liquor importers, hotels, restaurants, media, investors?
+8. Is the target customer Korean locals, international visitors, bartenders, or hospitality businesses?
+
+## Recommended Next Drafts
+
+- Investor one-pager.
+- Consulting service menu.
+- 12-slide partner deck.
+- Workshop curriculum.
+- Product pilot brief for tea tinctures / bottled bases.
+- 3-year financial model.
+
+## Final Recommendation
+
+Do not start with a distillery or product-heavy expansion. Start by turning Andy's existing credibility into a repeatable consulting, workshop, and event business while the flagship bar continues to generate proof and brand value. Use small product pilots to validate demand for tea spirits and tea-based non-alcoholic pairings before committing capital.


### PR DESCRIPTION
## Summary
- Adds a collaboration-ready business plan draft for #2.
- Notes that the linked Google Doc is not publicly accessible and lists assumptions.
- Covers positioning, customer segments, product architecture, revenue model, 12-month roadmap, risks, and collaboration questions.

## Deliverable
- andy-tea-scent-business-plan.md

## Notes
- Draft is based on the issue plus public material about Andy Yoon / Bar Tea Scent.
- Needs reconciliation with Andy's private Tea Scent plan once access is granted.

Closes #2